### PR TITLE
Add nnunetv2 package as optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This repository contains:
    > **Note:** If you pull a new version from GitHub, make sure to rerun this command with the flag `--upgrade`
    - nnunetv2 only usage
    ```bash
-   python3 -m pip install -e .
+   python3 -m pip install -e .[nnunetv2]
    ```
    - full usage (with Monai and other dependencies)
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auglab"
-version = "20251124"
+version = "20251125"
 requires-python = ">=3.10"
 description = "AugLab investigates the influence of different data augmentation strategies on MRI training performance."
 readme = "README.md"
@@ -28,11 +28,11 @@ keywords = [
 ]
 dependencies = [
     "batchgeneratorsv2",
-    "nnunetv2",
     "kornia"
 ]
 
 [project.optional-dependencies]
+nnunetv2 = ["nnunetv2"]
 all = [
     "torchio",
     "monai[all]",


### PR DESCRIPTION
## Description

To simplify the use of the package with [SCT](https://github.com/spinalcordtoolbox/spinalcordtoolbox) and [totalspineseg](https://github.com/neuropoly/totalspineseg), `nnunetv2` dependency was updated to become optional.