### PR TITLE
Add overwrite flag

### DIFF
--- a/auglab/add_trainer.py
+++ b/auglab/add_trainer.py
@@ -17,15 +17,20 @@ def main():
         required=True,
         help="nnUNetTrainer to be copied. Choices are: nnUNetTrainerDAExt and nnUNetTrainerTest",
     )
+    parser.add_argument(
+        '--overwrite', action='store_true',
+        help='Whether to overwrite existing trainer.'
+    )
     args = parser.parse_args()
 
     # Get trainer name
     trainer_name = args.trainer
+    overwrite = args.overwrite
 
     # Add trainer
-    add_trainer(trainer_name)
+    add_trainer(trainer_name, overwrite=overwrite)
 
-def add_trainer(trainer_name: str):
+def add_trainer(trainer_name: str, overwrite: bool = False):
 
     # Find trainer path
     trainers_path = importlib.resources.files(trainers)
@@ -42,10 +47,13 @@ def add_trainer(trainer_name: str):
 
     # Copy trainer
     output_path = nnunet_trainers_path / source_trainer.name
-    shutil.copy(source_trainer, output_path)
+    if not output_path.exists() or overwrite:
+        shutil.copy(source_trainer, output_path)
 
-    # Confirmation message
-    print(f"Trainer {trainer_name} was added to {output_path}")
+        # Confirmation message
+        print(f"Trainer {trainer_name} was added to {output_path}")
+    else:
+        print(f"Trainer {trainer_name} already exists at {output_path}. Use --overwrite to replace it.")
     
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Description

This PR adds a new flag `--overwrite` to the function `add_trainer` to avoid issues when write access is not available.

## Related issues

- https://github.com/neuropoly/totalspineseg/issues/124
- https://github.com/spinalcordtoolbox/spinalcordtoolbox/issues/5121